### PR TITLE
Fixes clearing all marks when no target is chosen

### DIFF
--- a/unmark
+++ b/unmark
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 name=`i3-msg -t get_marks | tr -d '[],' | sed -e 's/""/\n/g' | tr -d '"' | dmenu -p 'unmark'`;
-if [[ ! -z $name ]]
+if [[ -n $name ]]; then
     /usr/bin/i3-msg unmark $name
-endif
+fi


### PR DESCRIPTION
By default, i3 will clear all marks if `unmark` is sent without a target, which deletes all marks when the user hits `ESC` to exit `dmenu`. This adds an `if` block that tests whether the user entered nothing before trying to `unmark`. It now only messages i3 if the user actually selected a target, so all marks never get cleared at once.

It also adds a prompt to `unmark`, matching that of `goto` and `mark`.
