### PR TITLE
Improved reliability of searching by the name of the window

### DIFF
--- a/nextmatch
+++ b/nextmatch
@@ -15,7 +15,7 @@ def search_window(windows, expr):
     matches = []
     for (wm_class, name), L in windows.items():
         print(wm_class)
-        if regex.match(wm_class) or regex.match(name):
+        if regex.match(wm_class) or regex.search(name):
             matches.extend(L)
     return matches
 


### PR DESCRIPTION
Previously this script tried to do regex.match on the window names, which would only check the first word of the window name. This made it very unreliable, as a terminal window with the name "filename - NVIM" would not work when executing `python ~/bin/nextmatch nvim`.


I fixed this by using regex.search instead, which searches for the keyword in the whole window name.